### PR TITLE
Ac past training list

### DIFF
--- a/BangazonWorkforce/Controllers/TrainingProgramsController.cs
+++ b/BangazonWorkforce/Controllers/TrainingProgramsController.cs
@@ -70,8 +70,50 @@ namespace BangazonWorkforce.Controllers
                     }
                 }
 
+        //======= AUTHOR: ALLISON COLLINS ============
+        // GET: Index of past training programs, accessible from link at bottom of index page of future training programs
+        // GET: TrainingPrograms
+        public ActionResult PastIndex()
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"SELECT name, startdate,
+                                      enddate, maxattendees
+                                      FROM TrainingProgram;";
+                    SqlDataReader reader = cmd.ExecuteReader();
+
+                    List<TrainingProgram> trainingPrograms = new List<TrainingProgram>();
+
+                    /* set variable to timestamp here */
+                    DateTime CurrentDate = DateTime.Now;
+
+                    while (reader.Read())
+                    {
+                        TrainingProgram trainingProgram = new TrainingProgram
+                        {
+                            Name = reader.GetString(reader.GetOrdinal("Name")),
+                            StartDate = reader.GetDateTime(reader.GetOrdinal("StartDate")),
+                            EndDate = reader.GetDateTime(reader.GetOrdinal("EndDate")),
+                            MaxAttendees = reader.GetInt32(reader.GetOrdinal("MaxAttendees")),
+                        };
+
+                        /* add if statement to check for enddate */
+                        if (CurrentDate > trainingProgram.EndDate)
+                        {
+                            trainingPrograms.Add(trainingProgram);
+                        }
+                    }
+
+                    reader.Close();
+                    return View(trainingPrograms);
+                }
+            }
+        }
         //================================= AUTHOR: DANIEL BREWER ========================================= 
-        // GET: Departments/Create
+        // GET: TrainingProgram/Create
 
         public ActionResult Create()
         {

--- a/BangazonWorkforce/Models/TrainingProgram.cs
+++ b/BangazonWorkforce/Models/TrainingProgram.cs
@@ -11,11 +11,13 @@ namespace BangazonWorkforce.Models
     public class TrainingProgram
     {
         public int Id { get; set; }
-        [Display (Name = "Training Program")]
+        [Display (Name = "Program Name")]
         public string Name { get; set; }
-        [Display (Name = "Training Program Start Date")]
+        [Display (Name = "Start Date")]
         public DateTime StartDate { get; set; }
+        [Display(Name = "End Date")]
         public DateTime EndDate { get; set; }
+        [Display(Name = "Maximum Attendees")]
         public int MaxAttendees { get; set; }
     }
 

--- a/BangazonWorkforce/Views/Departments/Index.cshtml
+++ b/BangazonWorkforce/Views/Departments/Index.cshtml
@@ -43,3 +43,4 @@
 }
     </tbody>
 </table>
+

--- a/BangazonWorkforce/Views/TrainingPrograms/PastIndex.cshtml
+++ b/BangazonWorkforce/Views/TrainingPrograms/PastIndex.cshtml
@@ -1,14 +1,11 @@
 ﻿@model IEnumerable<BangazonWorkforce.Models.TrainingProgram>
 
 @{
-    ViewData["Title"] = "Index";
+    ViewData["Title"] = "PastIndex";
 }
 
-<h1>Index</h1>
+<h1>Past Programs</h1>
 
-<p>
-    <a asp-action="Create">Create New</a>
-</p>
 <table class="table">
     <thead>
         <tr>
@@ -42,16 +39,11 @@
             <td>
                 @Html.DisplayFor(modelItem => item.MaxAttendees)
             </td>
-            <td>
-                @Html.ActionLink("Edit", "Edit", new {  id=item.Id }) |
-                @Html.ActionLink("Details", "Details", new {  id=item.Id }) |
-            @*    @Html.ActionLink("Delete", "Delete", new {  id=item.Id }) *@
-            </td>
         </tr>
 }
     </tbody>
 </table>
 
 <div>
-    <a asp-action="PastIndex">View Past Programs</a>
+    <a asp-action="Index">Back to List</a>
 </div>

--- a/README.md
+++ b/README.md
@@ -47,10 +47,13 @@ and most powerful commericial platform for individuals all around the globe.
 - From details view, user can elect to delete a certain computer only if it has never been assigned to an employee
 
 ## Training Program Resource
-### Index
+### Index (Future Programs)
 - Author: Dan Brewer
 - User can see a list of all training programs that have not taken place yet
-## Create
+### Index (Past Programs)
+- Author: Allison Collins
+- From the Future Programs index page, user can click link to view past programs
+### Create
 - Author: Dan Brewer
 - User can create a new training program; creation form allows user to enter program title, start date, end date, and maximum number of employees
 


### PR DESCRIPTION
# Description

User can view past training programs when they click a link on the main program index page. Model display names have also been updated to fix minor formatting issues.

Fixes #15

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Testing Instructions

git fetch --all
git checkout ac-past-training-list
run BangazonWorkforce
click "training programs" in nav bar
click "view past programs" at bottom of page
you should be directed to a page showing past programs

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added test instructions that prove my fix is effective or that my feature works